### PR TITLE
fix compile error: ‘INT_MAX’ was not declared in this scope

### DIFF
--- a/src/storage/ct_styles.cc
+++ b/src/storage/ct_styles.cc
@@ -45,6 +45,7 @@
 #ifdef OLD_OP_CT
 #include "ct_old.h"
 #else
+#include <climits>
 #include "ct_typebased.h"
 #include "ct_none.h"
 #endif


### PR DESCRIPTION
Following the compilation instructions I got the above error. Fixed it...