### PR TITLE
fix a missing call to linkNode() in sat_impl

### DIFF
--- a/examples/test_implicit_kanban.cc
+++ b/examples/test_implicit_kanban.cc
@@ -175,6 +175,7 @@ int main(int argc, const char** argv)
     pr.setPessimistic();
     forest::policies p(false);
     p.setPessimistic();
+    // p.setQuasiReduced();
     
     //INITIAL STATE
     int* initialState;
@@ -192,7 +193,7 @@ int main(int argc, const char** argv)
       
       //CREATE FORESTS
       forest* inmdd = d->createForest(0, forest::BOOLEAN, forest::MULTI_TERMINAL,p);
-      forest* relmxd = d->createForest(0, forest::BOOLEAN, forest::MULTI_TERMINAL,p);
+      forest* relmxd = d->createForest(1, forest::BOOLEAN, forest::MULTI_TERMINAL,pr);
       
       expert_domain* dm = static_cast<expert_domain*>(inmdd->useDomain());
 

--- a/examples/test_implicit_pool.cc
+++ b/examples/test_implicit_pool.cc
@@ -155,6 +155,7 @@ int main(int argc, const char** argv)
     pr.setPessimistic();
     forest::policies p(false);
     p.setPessimistic();
+    // p.setQuasiReduced();
     
     //INITIAL STATE
     int* initialState;
@@ -171,7 +172,7 @@ int main(int argc, const char** argv)
       
       //CREATE FORESTS
       forest* inmdd = d->createForest(0, forest::BOOLEAN, forest::MULTI_TERMINAL,p);
-      forest* relmxd = d->createForest(0, forest::BOOLEAN, forest::MULTI_TERMINAL,p);
+      forest* relmxd = d->createForest(1, forest::BOOLEAN, forest::MULTI_TERMINAL,pr);
       
       expert_domain* dm = static_cast<expert_domain*>(inmdd->useDomain());
       

--- a/examples/test_implicit_smallos.cc
+++ b/examples/test_implicit_smallos.cc
@@ -101,7 +101,7 @@ const char* name = who;
 for (const char* ptr=who; *ptr; ptr++) {
 if ('/' == *ptr) name = ptr+1;
 }
-  printf("\nUsage: %s nnnn <-O> order\n\n", name);
+  printf("\nUsage: %s mt dc <-O> order\n\n", name);
   printf("\tnnnn: number of initial tokens\n");
   printf("\torder: the order of variables:123456789\n");
 return 1;
@@ -166,6 +166,7 @@ forest::policies pr(true);
   pr.setPessimistic();
 forest::policies p(false);
   p.setPessimistic();
+  // p.setQuasiReduced();
 
 //INITIAL STATE
 int* initialState;
@@ -184,7 +185,7 @@ if('i' == method)
 
 //CREATE FORESTS
   forest* inmdd = d->createForest(0, forest::BOOLEAN, forest::MULTI_TERMINAL,p);
-  forest* relmxd = d->createForest(0, forest::BOOLEAN, forest::MULTI_TERMINAL,p);
+  forest* relmxd = d->createForest(1, forest::BOOLEAN, forest::MULTI_TERMINAL,pr);
 
   expert_domain* dm = static_cast<expert_domain*>(inmdd->useDomain());
   dm->enlargeVariableBound(p1_position, false, MT+1);

--- a/src/operations/prepostimage.cc
+++ b/src/operations/prepostimage.cc
@@ -249,6 +249,7 @@ MEDDLY::node_handle MEDDLY::relXset_mdd::compute_rec(node_handle mdd, node_handl
       // loop over mxd "columns"
       for (unsigned jz=0; jz<Rp->getNNZs(); jz++) {
         unsigned j = Rp->i(jz);
+        MEDDLY_DCASSERT(0<=j && j < A->getSize());
         if (0==A->d(j))   continue; 
         // ok, there is an i->j "edge".
         // determine new states to be added (recursively)

--- a/src/operations/sat_impl.cc
+++ b/src/operations/sat_impl.cc
@@ -480,13 +480,11 @@ MEDDLY::satimpl_opname::implicit_relation::buildEventMxd(rel_node_handle eventTo
   rel_node_handle* rnh_array = (rel_node_handle*)malloc((nVars+1)*sizeof(rel_node_handle));
   // int top_level = Rnode->getLevel();
   
-  // domain* d = outsetF->useDomain();
   expert_forest* ef = (expert_forest*) mxd;
   
   //Get relation node handles
   for (int i=nVars; i>=1; i--)
     {
-    
       if(Rnode->getLevel()==i)// if variable i is a part of this event
         {
           rnh_array[i] = Rnode->getID(); // keep track of node_handles that are part of this event
@@ -505,6 +503,7 @@ MEDDLY::satimpl_opname::implicit_relation::buildEventMxd(rel_node_handle eventTo
     {
         if(rnh_array[i]!=-1)
           {
+            const int maxVar = ef->getDomain()->getVariableBound(i);
             Rnode = nodeExists(rnh_array[i]);
             //Create a new unprimed node for variable i
             MEDDLY_DCASSERT(outsetF->getVariableSize(i)>=Rnode->getPieceSize());
@@ -512,9 +511,10 @@ MEDDLY::satimpl_opname::implicit_relation::buildEventMxd(rel_node_handle eventTo
           
             for (int j=0; j<Rnode->getPieceSize(); j++) {
           
-              long new_j = confirmed[i][Rnode->getTokenUpdate()[j]]? Rnode->getTokenUpdate()[j] : -2;
+              // long new_j = confirmed[i][Rnode->getTokenUpdate()[j]]? Rnode->getTokenUpdate()[j] : -2;
+              long new_j = Rnode->getTokenUpdate()[j];
               
-              if(new_j>=0) 
+              if(new_j>=0 && new_j<maxVar) // do not exceed variable bounds
                 {
                    //Create primed node for each valid index of the unprimed node
                   unpacked_node* P_var = unpacked_node::newSparse(ef, -i, 1);
@@ -562,7 +562,8 @@ MEDDLY::satimpl_opname::implicit_relation::isUnionPossible(int level, long i, re
   if(lengthForLevel(level)==1)
      return false;
   
-   int* jset = (int*)malloc(lengthForLevel(level)*sizeof(int));
+  std::vector<int> jset(lengthForLevel(level), 0); 
+
    int last_j = 0;
    for(int k=0;k<lengthForLevel(level);k++)
     {

--- a/src/operations/sat_impl.cc
+++ b/src/operations/sat_impl.cc
@@ -1028,7 +1028,7 @@ MEDDLY::node_handle MEDDLY::forwd_impl_dfs_by_events_mt::recFireSet(
     mddUnion->compute(union_rec, ans, union_rec);
   }
   
-  return union_rec.getNode();
+  return resF->linkNode(union_rec.getNode());
 }
 
 


### PR DESCRIPTION
Fixes a missing linkNode() in sat_impl, that causes the operator to collect active MDDs nodes at the end of saturate().
The sat_impl operation has been broken for some time now, it now works perfectly in our tool after this change.
